### PR TITLE
fix: correct Disclaimer label typo

### DIFF
--- a/projects/website-angular/src/config/nav-options.json
+++ b/projects/website-angular/src/config/nav-options.json
@@ -49,7 +49,7 @@
         "link": "/about/privacy-notice"
       },
       "disclaimer": {
-        "label": "Discalaimer",
+        "label": "Disclaimer",
         "link": "/about/disclaimer"
       },
       "digital-preservation": {


### PR DESCRIPTION
Fixes #91\n\nCorrect the typo in the website navigation label from 'Discalaimer' to 'Disclaimer'.